### PR TITLE
target java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>23</source>
-                    <target>23</target>
+                    <source>21</source>
+                    <target>21</target>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
How about targeting lower java versions to not require latest JDK if it is not needed?

Maybe even lower version should be good?