### PR TITLE
Add functional tests for OptimalOpenHashMap

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
+
+concurrency:
+  # On main, we don't want any jobs cancelled so the sha is used to name the group
+  # On PR branches, we cancel the job if new commits are pushed
+  # More info: https://stackoverflow.com/a/68422069/253468
+  group: ${{ github.ref == 'refs/heads/main' && format('ci-main-{0}', github.sha) || format('ci-main-{0}', github.ref) }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ '17' ]
+    name: Test with Java ${{ matrix.java }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'temurin'
+          cache: maven
+      - name: Test
+        run: ./mvnw -B clean verify

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,12 @@
             <version>5.11.4</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava-testlib</artifactId>
+            <version>32.1.3-jre</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/src/test/java/com/royvanrijn/optimalopen/MapTest.java
+++ b/src/test/java/com/royvanrijn/optimalopen/MapTest.java
@@ -1,0 +1,57 @@
+package com.royvanrijn.optimalopen;
+
+import com.google.common.collect.testing.Helpers;
+import com.google.common.collect.testing.MapTestSuiteBuilder;
+import com.google.common.collect.testing.TestStringMapGenerator;
+import com.google.common.collect.testing.features.CollectionFeature;
+import com.google.common.collect.testing.features.CollectionSize;
+import com.google.common.collect.testing.features.MapFeature;
+import com.google.common.collect.testing.testers.MapEntrySetTester;
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+import java.util.Map;
+
+public class MapTest {
+
+    public static Test suite() {
+        TestSuite suite = new TestSuite("All tests");
+        suite.addTest(tests("OptimalOpenHashMap", new TestStringMapGenerator() {
+            @Override
+            protected Map<String, String> create(Map.Entry<String, String>[] entries) {
+                return populate(new OptimalOpenHashMap<>(), entries);
+            }
+        }));
+        suite.addTest(tests("LinearOpenHashMap", new TestStringMapGenerator() {
+            @Override
+            protected Map<String, String> create(Map.Entry<String, String>[] entries) {
+                return populate(new LinearOpenHashMap<>(), entries);
+            }
+        }));
+        return suite;
+    }
+
+    private static TestSuite tests(final String name, TestStringMapGenerator generator) {
+        return MapTestSuiteBuilder
+                .using(generator)
+                .named(name)
+                .withFeatures(
+                        MapFeature.GENERAL_PURPOSE,
+                        MapFeature.ALLOWS_ANY_NULL_QUERIES,
+                        MapFeature.RESTRICTS_KEYS,
+                        MapFeature.RESTRICTS_VALUES,
+                        CollectionFeature.GENERAL_PURPOSE,
+                        CollectionFeature.SERIALIZABLE,
+                        CollectionSize.ANY)
+                // Remove the suppression when entrySet() implementation improves
+                .suppressing(Helpers.getMethod(MapEntrySetTester.class, "testEntrySetIteratorRemove"))
+                .createTestSuite();
+    }
+
+    private static <T, M extends Map<T, String>> M populate(M map, Map.Entry<T, String>[] entries) {
+        for (Map.Entry<T, String> entry : entries) {
+            map.put(entry.getKey(), entry.getValue());
+        }
+        return map;
+    }
+}


### PR DESCRIPTION
The PR adds tests.
Note that `Map.Entry`, and `Map` require special implementations of `hashCode` and `equals`, so I updated the methods to match the spec.

Virtually all the tests pass, except `MapEntrySetTester.testEntrySetIteratorRemove`.
The test expects one of the following:
a) Either `entrySet().iterator().remove()` should work and removes the entry from the base map
b) Or `entrySet().iterator().remove()` should throw an exception

Currently, I add `testEntrySetIteratorRemove` to the suppression list, so the test skips.

I guess the solution would be to implement a customized `EntrySet` class instead of the current `new ...Set()`