### PR TITLE
Fix containsKey so it properly reports an entry with null value

### DIFF
--- a/src/main/java/com/royvanrijn/optimalopen/OptimalOpenHashMap.java
+++ b/src/main/java/com/royvanrijn/optimalopen/OptimalOpenHashMap.java
@@ -288,7 +288,9 @@ public class OptimalOpenHashMap<K, V> implements Map<K, V>, Serializable {
 
     @Override public int size() { return size; }
     @Override public boolean isEmpty() { return size == 0; }
-    @Override public boolean containsKey(Object key) { return get(key) != null; }
+    @Override public boolean containsKey(Object key) {
+        return funnelProbe(key, hash(key)) != -1;
+    }
     @Override public boolean containsValue(Object value) {
         for (Entry<K, V> e : table) {
             if (e != null && e != TOMBSTONE && Objects.equals(e.value, value))

--- a/src/test/java/com/royvanrijn/optimalopen/OptimalOpenHashMapTest.java
+++ b/src/test/java/com/royvanrijn/optimalopen/OptimalOpenHashMapTest.java
@@ -57,8 +57,10 @@ public class OptimalOpenHashMapTest {
     public void testContainsKey() {
         OptimalOpenHashMap<String, Integer> map = new OptimalOpenHashMap<>();
         map.put("key", 1);
+        map.put("nullvalue", null);
         assertTrue(map.containsKey("key"));
         assertFalse(map.containsKey("nonexistent"));
+        assertTrue( map.containsKey("nullvalue"), "containsKey(nullvalue) should return true as the key is present with null value");
     }
 
     @Test


### PR DESCRIPTION
The previous implementation was `get(key) != null` which returns false if the value itself is `null`.

guava-testlib does not detect such cases yet, however, I've filed a PR for that too https://github.com/google/guava/pull/7704